### PR TITLE
Add connection token retry logic

### DIFF
--- a/app/src/main/java/com/stripe/aod/sampleapp/network/TokenProvider.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/network/TokenProvider.kt
@@ -14,7 +14,7 @@ class TokenProvider(private val coroutineScope: CoroutineScope) : ConnectionToke
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
         coroutineScope.launch {
             try {
-                val token = ApiClient.createConnectionToken()
+                val token = ApiClient.createConnectionToken(canRetry = true)
                 callback.onSuccess(token)
             } catch (e: ConnectionTokenException) {
                 callback.onFailure(e)


### PR DESCRIPTION
We recommend render.com for backend hosting. The free tier is susceptible to timeouts when cold starting the host. Add a retry to mitigate the first request failing.

# How has this been tested?
- [ ] Automated
- [x] Manual
