### PR TITLE
Go directly home on skip receipt

### DIFF
--- a/app/src/main/java/com/stripe/aod/sampleapp/fragment/ReceiptFragment.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/fragment/ReceiptFragment.kt
@@ -3,14 +3,10 @@ package com.stripe.aod.sampleapp.fragment
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.google.android.material.snackbar.Snackbar
 import com.stripe.aod.sampleapp.R
-import com.stripe.aod.sampleapp.data.EmailReceiptParams
 import com.stripe.aod.sampleapp.databinding.FragmentReceiptBinding
-import com.stripe.aod.sampleapp.model.CheckoutViewModel
 import com.stripe.aod.sampleapp.utils.backToHome
 import com.stripe.aod.sampleapp.utils.formatCentsToString
 import com.stripe.aod.sampleapp.utils.navOptions
@@ -18,7 +14,6 @@ import com.stripe.aod.sampleapp.utils.setThrottleClickListener
 
 class ReceiptFragment : Fragment(R.layout.fragment_receipt) {
     private val args: ReceiptFragmentArgs by navArgs()
-    private val viewModel by viewModels<CheckoutViewModel>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -36,30 +31,8 @@ class ReceiptFragment : Fragment(R.layout.fragment_receipt) {
             )
         }
 
-        viewBinding.receiptSkip.setThrottleClickListener {
-            viewBinding.receiptSkip.isEnabled = false
-
-            viewModel.updateReceiptEmailPaymentIntent(
-                EmailReceiptParams(
-                    paymentIntentId = args.paymentIntentID,
-                    receiptEmail = ""
-                ),
-                successCallback = {
-                    backToHome()
-                },
-                failCallback = { message ->
-                    viewBinding.receiptSkip.isEnabled = true
-                    Snackbar.make(
-                        viewBinding.receiptSkip,
-                        if (message.isNullOrEmpty()) {
-                            getString(R.string.error_fail_to_capture_payment_intent)
-                        } else {
-                            message
-                        },
-                        Snackbar.LENGTH_SHORT
-                    ).show()
-                }
-            )
+        viewBinding.receiptSkip.setOnClickListener {
+            backToHome()
         }
     }
 }


### PR DESCRIPTION
We don't need to make an update API call if we're not sending an email receipt.

# How has this been tested?
- [ ] Automated
- [x] Manual
