### PR TITLE
Update Terminal SDK to 3.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace = "com.stripe.aod.sampleapp"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.stripe.aod.sampleapp"
         minSdk = 28
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace = "com.stripe.aod.sampleapp"
-    compileSdk = 34
+    compileSdk = 33
 
     defaultConfig {
         applicationId = "com.stripe.aod.sampleapp"
         minSdk = 28
-        targetSdk = 34
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,11 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11.toString()
+        allWarningsAsErrors = true
+    }
+
     buildFeatures {
         viewBinding = true
     }

--- a/app/src/main/java/com/stripe/aod/sampleapp/activity/MainActivity.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/activity/MainActivity.kt
@@ -102,7 +102,7 @@ class MainActivity : AppCompatActivity() {
                 applicationContext,
                 LogLevel.VERBOSE,
                 viewModel.tokenProvider,
-                TerminalEventListener(viewModel)
+                TerminalEventListener,
             )
 
             viewModel.discoveryReaders()

--- a/app/src/main/java/com/stripe/aod/sampleapp/fragment/InputFragment.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/fragment/InputFragment.kt
@@ -91,7 +91,7 @@ class InputFragment : Fragment(R.layout.fragment_input), OnTouchListener {
                 }?.let {
                     findNavController().navigate(
                         InputFragmentDirections.actionInputFragmentToReceiptFragment(
-                            paymentIntentID = it.id,
+                            paymentIntentID = it.id.orEmpty(),
                             amount = it.amount.toInt()
                         ),
                         navOptions()

--- a/app/src/main/java/com/stripe/aod/sampleapp/listener/TerminalEventListener.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/listener/TerminalEventListener.kt
@@ -2,35 +2,57 @@ package com.stripe.aod.sampleapp.listener
 
 import android.util.Log
 import com.stripe.aod.sampleapp.Config
-import com.stripe.aod.sampleapp.model.MainViewModel
 import com.stripe.stripeterminal.external.callable.TerminalListener
 import com.stripe.stripeterminal.external.models.ConnectionStatus
 import com.stripe.stripeterminal.external.models.PaymentStatus
 import com.stripe.stripeterminal.external.models.Reader
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 
 /**
  * The `TerminalEventListener` implements the [TerminalListener] interface and will
  * forward along any events to other parts of the app that register for updates.
  *
  */
-class TerminalEventListener(private val viewModel: MainViewModel) : TerminalListener {
+object TerminalEventListener : TerminalListener {
+    private val _onUnexpectedReaderDisconnect = MutableSharedFlow<Reader>()
+    private val _onConnectionStatusChange = MutableSharedFlow<ConnectionStatus>()
+    private val _onPaymentStatusChange = MutableSharedFlow<PaymentStatus>()
+
+    val onUnexpectedReaderDisconnect = _onUnexpectedReaderDisconnect.asSharedFlow()
+    val onConnectionStatusChange = _onConnectionStatusChange.asSharedFlow()
+    val onPaymentStatusChange = _onPaymentStatusChange.asSharedFlow()
+
+    private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun onUnexpectedReaderDisconnect(reader: Reader) {
         Log.i(
             Config.TAG,
             "onUnexpectedReaderDisconnect Reader serial number: ${reader.serialNumber}"
         )
-        // Reconnect the device
-        viewModel.connectReader()
+
+        scope.launch {
+            _onUnexpectedReaderDisconnect.emit(reader)
+        }
     }
 
     override fun onConnectionStatusChange(status: ConnectionStatus) {
         Log.i(Config.TAG, "onConnectionStatusChange: $status")
-        viewModel.updateConnectStatus(status)
+
+        scope.launch {
+            _onConnectionStatusChange.emit(status)
+        }
     }
 
     override fun onPaymentStatusChange(status: PaymentStatus) {
         Log.i(Config.TAG, "onPaymentStatusChange: $status")
-        viewModel.updatePaymentStatus(status)
+
+        scope.launch {
+            _onPaymentStatusChange.emit(status)
+        }
+
     }
 }

--- a/app/src/main/java/com/stripe/aod/sampleapp/model/CheckoutViewModel.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/model/CheckoutViewModel.kt
@@ -97,7 +97,7 @@ class CheckoutViewModel : ViewModel() {
 
     private suspend fun processPayment(paymentIntent: PaymentIntent): PaymentIntent {
         return suspendCoroutine { continuation ->
-            Terminal.getInstance().processPayment(
+            Terminal.getInstance().confirmPaymentIntent(
                 paymentIntent,
                 object : PaymentIntentCallback {
                     override fun onSuccess(paymentIntent: PaymentIntent) {
@@ -144,5 +144,5 @@ class CheckoutViewModel : ViewModel() {
             }
 
     private suspend fun capturePaymentIntent(paymentIntent: PaymentIntent) =
-        ApiClient.capturePaymentIntent(paymentIntent.id)
+        ApiClient.capturePaymentIntent(paymentIntent.id.orEmpty())
 }

--- a/app/src/main/java/com/stripe/aod/sampleapp/model/MainViewModel.kt
+++ b/app/src/main/java/com/stripe/aod/sampleapp/model/MainViewModel.kt
@@ -85,16 +85,13 @@ class MainViewModel : ViewModel() {
         }
     }
 
+    @Suppress("MissingPermission")
     fun discoveryReaders() {
-        try {
-            discoveryTask = Terminal.getInstance().discoverReaders(
-                config,
-                discoveryListener,
-                discoveryCallback
-            )
-        } catch (e: SecurityException) {
-            Log.e(Config.TAG, "Failed to discover readers", e)
-        }
+        discoveryTask = Terminal.getInstance().discoverReaders(
+            config,
+            discoveryListener,
+            discoveryCallback
+        )
     }
 
     fun connectReader() {
@@ -136,11 +133,11 @@ class MainViewModel : ViewModel() {
         )
     }
 
-    fun updateConnectStatus(status: ConnectionStatus) {
+    private fun updateConnectStatus(status: ConnectionStatus) {
         _readerConnectStatus.update { status }
     }
 
-    fun updatePaymentStatus(status: PaymentStatus) {
+    private fun updatePaymentStatus(status: PaymentStatus) {
         _readerPaymentStatus.update { status }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lifecycle-version = "2.6.1"
 navigation-version = "2.5.3"
 retrofit-version = "2.9.0"
-stripeterminal-version = "2.21.0"
+stripeterminal-version = "3.0.0"
 
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lifecycle-version = "2.6.1"
 navigation-version = "2.5.3"
 retrofit-version = "2.9.0"
-stripeterminal-version = "3.0.0"
+stripeterminal-version = "3.1.0"
 
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"


### PR DESCRIPTION
Also remove `TerminalEventListener` dependency on `MainViewModel`, this was causing a memory leak.

# How has this been tested?
- [x] Automated
- [x] Manual

## Reproducible test instructions
Manually verified by running through a transaction