### PR TITLE
libs.versions.toml: Bump Terminal SDK to 5.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lifecycle-version = "2.8.7"
 navigation-version = "2.8.8"
 retrofit-version = "2.11.0"
-stripeterminal-version = "5.2.0"
+stripeterminal-version = "5.3.0"
 
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.0"


### PR DESCRIPTION
# How has this been tested?
- [x] Automated
- [ ] Manual
